### PR TITLE
Pages for living people - additional checks

### DIFF
--- a/src/org/werelate/search/DataQualityRequestHandler.java
+++ b/src/org/werelate/search/DataQualityRequestHandler.java
@@ -61,7 +61,7 @@ public class DataQualityRequestHandler extends RequestHandlerBase {
       }
 
       // Get issues for a family page or for a child in relation to the parents' family page
-      // Also get earliest and latest birth years needed to determine if the husband, wife, or child might be living.
+      // Also get latest birth years needed to determine if the husband, wife, or child might be living.
       if (namespace.equals("Family")) {
          String familyTitle = params.get("ftitle");
          String childTitle = params.get("ctitle");
@@ -73,11 +73,8 @@ public class DataQualityRequestHandler extends RequestHandlerBase {
             familyDQAnalysis.refineHusbandBirthYear();
             familyDQAnalysis.refineWifeBirthYear();
          }
-         rsp.add("hEarliestBirth", familyDQAnalysis.getHEarliestBirth());
          rsp.add("hLatestBirth", familyDQAnalysis.getHLatestBirth());
-         rsp.add("wEarliestBirth", familyDQAnalysis.getWEarliestBirth());
          rsp.add("wLatestBirth", familyDQAnalysis.getWLatestBirth());
-         rsp.add("cEarliestBirth", familyDQAnalysis.getCEarliestBirth());
          rsp.add("cLatestBirth", familyDQAnalysis.getCLatestBirth());
          issues = familyDQAnalysis.getIssues();
          addIssuesToResponse(issues, rsp);

--- a/src/org/werelate/search/DataQualityRequestHandler.java
+++ b/src/org/werelate/search/DataQualityRequestHandler.java
@@ -49,19 +49,36 @@ public class DataQualityRequestHandler extends RequestHandlerBase {
       Element root = Utils.parseText(new Builder(), data, true).getRootElement();
       String[][] issues = new String[1000][4];
 
-      // Get issues for a person page
+      // Get issues for a person page, and variables needed to determine whether the person might be living.
       if (namespace.equals("Person")) {
          String personTitle = params.get("pTitle");
          PersonDQAnalysis personDQAnalysis = new PersonDQAnalysis(root, personTitle);
+         rsp.add("earliestBirth", personDQAnalysis.getEarliestBirth());
+         rsp.add("latestBirth", personDQAnalysis.getLatestBirth());
+         rsp.add("isDeadOrExempt", personDQAnalysis.isDeadOrExempt());
          issues = personDQAnalysis.getIssues();
          addIssuesToResponse(issues, rsp);
       }
 
       // Get issues for a family page or for a child in relation to the parents' family page
+      // Also get earliest and latest birth years needed to determine if the husband, wife, or child might be living.
       if (namespace.equals("Family")) {
          String familyTitle = params.get("ftitle");
          String childTitle = params.get("ctitle");
          FamilyDQAnalysis familyDQAnalysis = new FamilyDQAnalysis(root, familyTitle, childTitle);
+         if (!childTitle.equals("none")) {
+            familyDQAnalysis.refineChildBirthYear();
+         }
+         else {
+            familyDQAnalysis.refineHusbandBirthYear();
+            familyDQAnalysis.refineWifeBirthYear();
+         }
+         rsp.add("hEarliestBirth", familyDQAnalysis.getHEarliestBirth());
+         rsp.add("hLatestBirth", familyDQAnalysis.getHLatestBirth());
+         rsp.add("wEarliestBirth", familyDQAnalysis.getWEarliestBirth());
+         rsp.add("wLatestBirth", familyDQAnalysis.getWLatestBirth());
+         rsp.add("cEarliestBirth", familyDQAnalysis.getCEarliestBirth());
+         rsp.add("cLatestBirth", familyDQAnalysis.getCLatestBirth());
          issues = familyDQAnalysis.getIssues();
          addIssuesToResponse(issues, rsp);
       }


### PR DESCRIPTION
Reduce the likelihood of creation of pages for living people by determining or refining the birth date range based on other dates.